### PR TITLE
execute start.sh using bash instead of sh

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,6 +1,6 @@
 all:
 	docker images | grep -q ^r2wars || docker build --no-cache -t r2wars .
-	sh start.sh
+	bash -c "trap './start.sh' EXIT;"
 
 clean:
 	docker rmi r2wars


### PR DESCRIPTION
also catches SIGINT to avoid make claiming the build failed when shutting down webserver

**Checklist**

- [x] Closing issues: #11 
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some documentation

