### PR TITLE
Pin version for Ubuntu to 22.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:labs
-ARG UBUNTU_RELEASE="latest"
+ARG UBUNTU_RELEASE="22.04"
 ARG TIMEZONE="UTC"
 ARG R2_SOURCE="https://github.com/radareorg/radare2.git"
 ARG R2_INSTALL_DIR="/opt/r2"


### PR DESCRIPTION
**Checklist**

- [x] Closing issues: #15 
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some documentation

**Description**

This PR fixes the Dockerfile to pin the version of the used Ubuntu Container to Ubuntu 22.04 LTS, where the `nuget` package is present. The `latest` one does not have `nuget` in its repository. The output of the build changes as shown below:

```
[+] Building 81.3s (16/22)                                                                                                                                                          docker:default
 => [internal] load build definition from Dockerfile                                                                                                                                          0.0s
 => => transferring dockerfile: 3.48kB                                                                                                                                                        0.0s
 => resolve image config for docker-image://docker.io/docker/dockerfile:labs                                                                                                                  1.3s
 => CACHED docker-image://docker.io/docker/dockerfile:labs@sha256:b99fecfe00268a8b556fad7d9c37ee25d716ae08a5d7320e6d51c4dd83246894                                                            0.0s
 => [internal] load metadata for docker.io/library/ubuntu:latest                                                                                                                              0.0s
 => [internal] load .dockerignore                                                                                                                                                             0.0s
 => => transferring context: 150B                                                                                                                                                             0.0s
 => [internal] load build context                                                                                                                                                             0.1s
 => => transferring context: 4.56MB                                                                                                                                                           0.0s
 => [r2-builder 2/4] ADD https://github.com/radareorg/radare2.git /r2src                                                                                                                      2.5s
 => [base 1/3] FROM docker.io/library/ubuntu:latest                                                                                                                                           0.0s
 => CACHED [base 2/3] RUN ln -snf /usr/share/zoneinfo/UTC /etc/localtime &&     echo UTC > /etc/timezone                                                                                      0.0s
 => CACHED [base 3/3] RUN rm -f /etc/apt/apt.conf.d/docker-clean &&     echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache                            0.0s
 => ERROR [runner 1/4] RUN --mount=type=cache,target=/var/cache/apt,sharing=locked     --mount=type=cache,target=/var/lib/apt,sharing=locked     apt-get update &&     apt-get install -y --  5.6s
 => [r2wars-builder 1/4] RUN --mount=type=cache,target=/var/cache/apt,sharing=locked     --mount=type=cache,target=/var/lib/apt,sharing=locked     apt-get update &&     apt-get install -y  79.5s
 => CACHED [r2-builder 1/4] RUN --mount=type=cache,target=/var/cache/apt,sharing=locked     --mount=type=cache,target=/var/lib/apt,sharing=locked     apt-get update &&     apt-get install   0.0s
 => [r2-builder 2/4] ADD https://github.com/radareorg/radare2.git /r2src                                                                                                                      0.6s
 => [r2-builder 3/4] WORKDIR /r2src                                                                                                                                                           0.1s
 => CANCELED [r2-builder 4/4] RUN --mount=type=cache,id=ccache,target=/root/.cache/ccache,sharing=shared     meson setup build         -Dbuildtype=release         -Dprefix=/opt/r2          76.1s
------
 > [runner 1/4] RUN --mount=type=cache,target=/var/cache/apt,sharing=locked     --mount=type=cache,target=/var/lib/apt,sharing=locked     apt-get update &&     apt-get install -y --no-install-recommends         mono-runtime         nuget:
0.535 Get:1 http://archive.ubuntu.com/ubuntu noble InRelease [256 kB]
0.549 Get:2 http://security.ubuntu.com/ubuntu noble-security InRelease [126 kB]
1.206 Get:3 http://security.ubuntu.com/ubuntu noble-security/restricted amd64 Packages [68.2 kB]
1.321 Get:4 http://archive.ubuntu.com/ubuntu noble-updates InRelease [126 kB]
1.379 Get:5 http://security.ubuntu.com/ubuntu noble-security/main amd64 Packages [165 kB]
1.466 Get:6 http://archive.ubuntu.com/ubuntu noble-backports InRelease [126 kB]
1.537 Get:7 http://security.ubuntu.com/ubuntu noble-security/universe amd64 Packages [47.5 kB]
1.629 Get:8 http://archive.ubuntu.com/ubuntu noble/multiverse amd64 Packages [331 kB]
1.732 Get:9 http://archive.ubuntu.com/ubuntu noble/restricted amd64 Packages [117 kB]
1.769 Get:10 http://archive.ubuntu.com/ubuntu noble/main amd64 Packages [1808 kB]
1.997 Get:11 http://archive.ubuntu.com/ubuntu noble/universe amd64 Packages [19.3 MB]
3.503 Get:12 http://archive.ubuntu.com/ubuntu noble-updates/restricted amd64 Packages [68.2 kB]
3.508 Get:13 http://archive.ubuntu.com/ubuntu noble-updates/main amd64 Packages [188 kB]
3.521 Get:14 http://archive.ubuntu.com/ubuntu noble-updates/universe amd64 Packages [72.3 kB]
3.536 Get:15 http://archive.ubuntu.com/ubuntu noble-backports/universe amd64 Packages [7519 B]
4.421 Fetched 22.8 MB in 4s (5520 kB/s)
4.421 Reading package lists...
5.212 Reading package lists...
5.223 Building dependency tree...
5.415 Reading state information...
5.439 Package nuget is not available, but is referred to by another package.
5.439 This may mean that the package is missing, has been obsoleted, or
5.439 is only available from another source
5.439 
5.441 E: Package 'nuget' has no installation candidate
------
Dockerfile:90
--------------------
  89 |     # Install base packages
  90 | >>> RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
  91 | >>>     --mount=type=cache,target=/var/lib/apt,sharing=locked \
  92 | >>>     apt-get update && \
  93 | >>>     apt-get install -y --no-install-recommends \
  94 | >>>         mono-runtime \
  95 | >>>         nuget
  96 |     
--------------------
ERROR: failed to solve: process "/bin/sh -c apt-get update &&     apt-get install -y --no-install-recommends         mono-runtime         nuget" did not complete successfully: exit code: 100
``` 
to 

```
[+] Building 50.1s (23/23) FINISHED                                                                                                                                                 docker:default
 => [internal] load build definition from Dockerfile                                                                                                                                          0.0s
 => => transferring dockerfile: 3.48kB                                                                                                                                                        0.0s
 => resolve image config for docker-image://docker.io/docker/dockerfile:labs                                                                                                                  0.4s
 => CACHED docker-image://docker.io/docker/dockerfile:labs@sha256:b99fecfe00268a8b556fad7d9c37ee25d716ae08a5d7320e6d51c4dd83246894                                                            0.0s
 => [internal] load metadata for docker.io/library/ubuntu:22.04                                                                                                                               0.0s
 => [internal] load .dockerignore                                                                                                                                                             0.0s
 => => transferring context: 150B                                                                                                                                                             0.0s
 => [internal] load build context                                                                                                                                                             0.0s
 => => transferring context: 9.92kB                                                                                                                                                           0.0s
 => CACHED [r2-builder 2/4] ADD https://github.com/radareorg/radare2.git /r2src                                                                                                               1.1s
 => [base 1/3] FROM docker.io/library/ubuntu:22.04                                                                                                                                            0.0s
 => CACHED [base 2/3] RUN ln -snf /usr/share/zoneinfo/UTC /etc/localtime &&     echo UTC > /etc/timezone                                                                                      0.0s
 => CACHED [base 3/3] RUN rm -f /etc/apt/apt.conf.d/docker-clean &&     echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache                            0.0s
 => CACHED [r2-builder 1/4] RUN --mount=type=cache,target=/var/cache/apt,sharing=locked     --mount=type=cache,target=/var/lib/apt,sharing=locked     apt-get update &&     apt-get install   0.0s
 => [r2-builder 2/4] ADD https://github.com/radareorg/radare2.git /r2src                                                                                                                      0.6s
 => [r2-builder 3/4] WORKDIR /r2src                                                                                                                                                           0.1s
 => [r2-builder 4/4] RUN --mount=type=cache,id=ccache,target=/root/.cache/ccache,sharing=shared     meson setup build         -Dbuildtype=release         -Dprefix=/opt/r2         -Dlocal=  46.4s
 => CACHED [runner 1/4] RUN --mount=type=cache,target=/var/cache/apt,sharing=locked     --mount=type=cache,target=/var/lib/apt,sharing=locked     apt-get update &&     apt-get install -y -  0.0s
 => CACHED [r2wars-builder 1/4] RUN --mount=type=cache,target=/var/cache/apt,sharing=locked     --mount=type=cache,target=/var/lib/apt,sharing=locked     apt-get update &&     apt-get inst  0.0s
 => CACHED [r2wars-builder 2/4] COPY --link csharp /r2wars                                                                                                                                    0.0s
 => CACHED [r2wars-builder 3/4] WORKDIR /r2wars                                                                                                                                               0.0s
 => CACHED [r2wars-builder 4/4] RUN xbuild /p:Configuration=Release r2wars.csproj                                                                                                             0.0s
 => CACHED [runner 2/4] COPY --from=r2wars-builder --link /r2wars/bin/Release /r2wars                                                                                                         0.0s
 => [runner 3/4] COPY --from=r2-builder --link /opt/r2 /opt/r2                                                                                                                                0.2s
 => [runner 4/4] WORKDIR /r2wars                                                                                                                                                              0.1s
 => exporting to image                                                                                                                                                                        0.6s
 => => exporting layers                                                                                                                                                                       0.6s
 => => writing image sha256:be58f1093affc782f0d4c0730fb822eb4db5cf6d64bdb15a529c0042764fa95c                                                                                                  0.0s
 => => naming to docker.io/library/r2nw       
```

In case there is something to improve, let me know :)